### PR TITLE
Update AsciiDoc markup to AsciiRFC v3

### DIFF
--- a/rfc/document.adoc
+++ b/rfc/document.adoc
@@ -4,7 +4,7 @@
 :abbrev: AsciiRFC Example
 :status: informational
 :ipr: trust200902
-:submissionType: individual
+:submission-type: individual
 :area: Internet
 :intended-series: full-standard
 :revdate: 2018-12-12T00:00:00Z
@@ -30,9 +30,9 @@
 :country_2: United States of America
 :uri_2: https://www.brown.edu
 :email_2: truman.grayson@ribose.com
-:docfile: draft-asciirfc-minimal.adoc
+:docfile: document.adoc
 :mn-document-class: ietf
-:mn-output-extensions: xmlrfc2,txt,html,nits
+:mn-output-extensions: xmlrfc3,txt,html,nits
 
 include::sections/00-abstract.adoc[]
 include::sections/01-intro.adoc[]

--- a/rfc/sections/00-abstract.adoc
+++ b/rfc/sections/00-abstract.adoc
@@ -1,5 +1,7 @@
-[abstract]
 
+[[abstract-id]]
+[abstract]
+== Abstract
 This document provides a template on how to author (or migrate!)
 a new Internet-Draft / RFC in the AsciiRFC format.
 

--- a/rfc/sections/01-intro.adoc
+++ b/rfc/sections/01-intro.adoc
@@ -1,5 +1,5 @@
 
-[#introduction]
+[[introduction]]
 == Introduction
 
 AsciiRFC <<I-D.ribose-asciirfc>> is an extremely simple way to

--- a/rfc/sections/02-conventions.adoc
+++ b/rfc/sections/02-conventions.adoc
@@ -1,5 +1,5 @@
 
-[#conventions]
+[[conventions]]
 == Terms and Definitions
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*",

--- a/rfc/sections/03-symbols.adoc
+++ b/rfc/sections/03-symbols.adoc
@@ -1,5 +1,5 @@
 
-[#symbols]
+[[symbols]]
 == Symbols And Abbreviations
 
 ADRFC::

--- a/rfc/sections/04-content.adoc
+++ b/rfc/sections/04-content.adoc
@@ -1,5 +1,5 @@
 
-[#main]
+[[main]]
 == Main content
 
 This is where you place the main content, and the following
@@ -45,7 +45,7 @@ You will need to have:
 * This is an external reference <<RNP>>
 
 
-[#code-snippets]
+[[code-snippets]]
 === Code snippets
 
 Code snippets should be wrapped with `<CODE BEGINS>` and

--- a/rfc/sections/10-security.adoc
+++ b/rfc/sections/10-security.adoc
@@ -1,5 +1,5 @@
 
-[#security]
+[[security]]
 == Security Considerations
 
 Any security considerations should be placed here.

--- a/rfc/sections/11-iana.adoc
+++ b/rfc/sections/11-iana.adoc
@@ -1,5 +1,5 @@
 
-[#iana]
+[[iana]]
 == IANA Considerations
 
 This document does not require any action by IANA.

--- a/rfc/sections/97-examples.adoc
+++ b/rfc/sections/97-examples.adoc
@@ -1,6 +1,6 @@
 
 [appendix]
-[#appendix-a]
+[[appendix-a]]
 == Examples
 
 === Example 1

--- a/rfc/sections/98-references.adoc
+++ b/rfc/sections/98-references.adoc
@@ -1,24 +1,21 @@
-
-== Bibliography
-
 [bibliography]
-=== Normative References
+== Normative References
 
 * [[[RFC2119,RFC 2119]]], _Key words for use in RFCs to Indicate Requirement Levels_.
 * [[[RFC7991,RFC 7991]]], _The "xml2rfc" Version 3 Vocabulary_.
 * [[[RFC8174,RFC 8174]]], _ Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words_.
 
 [bibliography]
-=== Informative References
+== Informative References
 
-* [[[IETF.TLP,IETF TRUST]]], _Legal Provisions Relating to IETF Documents_.
+* [[[IETF.TLP,IETF.TLP]]], _Legal Provisions Relating to IETF Documents_.
 * [[[I-D.ribose-asciirfc,IETF(I-D.ribose-asciirfc-08)]]], _AsciiRFC: Authoring Internet-Drafts And RFCs Using AsciiDoc -- draft-ribose-asciirfc-08_.
 * [[[RFC3552,RFC 3552]]], _Guidelines for Writing RFC Text on Security Considerations_.
 * [[[RFC5378,RFC 5378]]], _Rights Contributors Provide to the IETF Trust_.
 * [[[RFC7253,RFC 7253]]], _The OCB Authenticated-Encryption Algorithm_.
 
 [%bibitem]
-==== RNP: A C library approach to OpenPGP
+=== RNP: A C library approach to OpenPGP
 id:: RNP
 contributor::
 contributor:organization.name:: Ribose Inc.

--- a/rfc/sections/98-references.adoc
+++ b/rfc/sections/98-references.adoc
@@ -1,15 +1,31 @@
 
-[bibliography]
-== Normative References
-
-++++
-include::../references/normative/*[]
-++++
+== Bibliography
 
 [bibliography]
-== Informative References
+=== Normative References
 
-++++
-include::../references/informative/*.xml[]
-++++
+* [[[RFC2119,RFC 2119]]], _Key words for use in RFCs to Indicate Requirement Levels_.
+* [[[RFC7991,RFC 7991]]], _The "xml2rfc" Version 3 Vocabulary_.
+* [[[RFC8174,RFC 8174]]], _ Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words_.
 
+[bibliography]
+=== Informative References
+
+* [[[IETF.TLP,IETF TRUST]]], _Legal Provisions Relating to IETF Documents_.
+* [[[I-D.ribose-asciirfc,IETF(I-D.ribose-asciirfc-08)]]], _AsciiRFC: Authoring Internet-Drafts And RFCs Using AsciiDoc -- draft-ribose-asciirfc-08_.
+* [[[RFC3552,RFC 3552]]], _Guidelines for Writing RFC Text on Security Considerations_.
+* [[[RFC5378,RFC 5378]]], _Rights Contributors Provide to the IETF Trust_.
+* [[[RFC7253,RFC 7253]]], _The OCB Authenticated-Encryption Algorithm_.
+
+[%bibitem]
+==== RNP: A C library approach to OpenPGP
+id:: RNP
+contributor::
+contributor:organization.name:: Ribose Inc.
+contributor:organization.contact::
+contributor:organization.contact.street:: Suite 1111, 1 Pedder Street
+contributor:organization.contact.region:: Central
+contributor:organization.contact.country:: Hong Kong
+contributor:organization.contact.city:: Hong Kong
+contributor:organization.contact.email:: open.source@ribose.com
+contributor:organization.contact.uri:: https://www.ribose.com

--- a/rfc/sections/99-acknowledgements.adoc
+++ b/rfc/sections/99-acknowledgements.adoc
@@ -1,5 +1,5 @@
 
-[#acknowledgements]
+[[acknowledgements]]
 == Acknowledgements
 
 The authors would like to thank their families.


### PR DESCRIPTION
*From https://github.com/metanorma/mn-templates-ietf/issues/6*

Here, the only updates that I considered necessary were the *anchors markup*. Unless you want me to add additional content to illustrate other markups. Please let me know if I should make further changes.

Thanks!