### PR TITLE
metanorma/metanorma-build-scripts#66 Drop ruby 2.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,18 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        ruby: [ '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5' ]
         experimental: [ false ]
-        include:
-          - ruby: '3.0'
-            os: macos-latest
-            experimental: true
-          - ruby: '3.0'
-            os: ubuntu-latest
-            experimental: true
-          - ruby: '3.0'
-            os: windows-latest
-            experimental: true
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,6 +47,10 @@ jobs:
               lines.append('gem "{}", github: "{}"{}\n'.format(repo.split("/", 1)[1], repo, gem_branch))
 
             gemfile.writelines(lines)
+
+      - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+        with:
+          token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/common/.github/workflows/docker.yml
+++ b/common/.github/workflows/docker.yml
@@ -9,10 +9,7 @@ on:
     paths-ignore:
       - .gitlab-ci.yml
       - .github/workflows/test.yml
-      - .github/workflows/macos.yml
-      - .github/workflows/ubuntu.yml
-      - .github/workflows/windows.yml
-      - .github/workflows/docker-pres_xml.yml
+      - .github/workflows/generate.yml
   repository_dispatch:
     types: [ metanorma/metanorma-docker ]
 
@@ -32,9 +29,22 @@ jobs:
           key: fontist-docker
           restore-keys: fontist-docker
 
-      - run: curl -L --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/gemfile-to-bundle-add.sh | bash
+      - uses: actions/cache@v2
+        with:
+          path: ~/.metanorma-ietf-workgroup-cache.json
+          key: metanorma-ietf-workgroup-cache
+          restore-keys: metanorma-ietf-workgroup-cache
 
-      - run: metanorma site generate --agree-to-terms
+      - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
+        with:
+          token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+
+      - run: |
+          curl -L --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/gemfile-to-bundle-add.sh | bash
+
+      - uses: actions-mn/cli/site-gen@main
+        with:
+          agree-to-terms: true
 
       - uses: actions/upload-artifact@master
         with:
@@ -54,7 +64,7 @@ jobs:
 
       - uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.GH_DEPLOY_KEY }}
+          github_token: ${{ github.token }}
           publish_dir: ./site
           force_orphan: true
           user_name: ${{ github.actor }}
@@ -63,5 +73,5 @@ jobs:
 
       - uses: kolpav/purge-artifacts-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           expire-in: 0

--- a/common/.github/workflows/generate.yml
+++ b/common/.github/workflows/generate.yml
@@ -10,7 +10,6 @@ on:
       - .gitlab-ci.yml
       - .github/workflows/test.yml
       - .github/workflows/docker.yml
-      - .github/workflows/docker-pres_xml.yml
   workflow_dispatch:
 
 jobs:
@@ -39,6 +38,17 @@ jobs:
           key: fontist-${{ runner.os }}
           restore-keys: fontist-${{ runner.os }}
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.metanorma-ietf-workgroup-cache.json
+          key: metanorma-ietf-workgroup-cache
+          restore-keys: metanorma-ietf-workgroup-cache
+
+      - if: matrix.os == 'windows-latest'
+        run: rm Gemfile
+
       - uses: actions-mn/setup@master
 
-      - run: metanorma site generate --agree-to-terms
+      - uses: actions-mn/cli/site-gen@main
+        with:
+          agree-to-terms: true


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.