### PR TITLE
Correct xref anchor for AsciiBib reference

### DIFF
--- a/rfc/sections/98-references.adoc
+++ b/rfc/sections/98-references.adoc
@@ -14,6 +14,7 @@
 * [[[RFC5378,RFC 5378]]], _Rights Contributors Provide to the IETF Trust_.
 * [[[RFC7253,RFC 7253]]], _The OCB Authenticated-Encryption Algorithm_.
 
+[[RNP]]
 [%bibitem]
 === RNP: A C library approach to OpenPGP
 id:: RNP


### PR DESCRIPTION
In regard to https://github.com/metanorma/mn-templates-ietf/issues/28