### PR TITLE
Revert "fix: Correct cross-ref anchor for AsciiBib reference"

### DIFF
--- a/rfc/sections/98-references.adoc
+++ b/rfc/sections/98-references.adoc
@@ -14,7 +14,6 @@
 * [[[RFC5378,RFC 5378]]], _Rights Contributors Provide to the IETF Trust_.
 * [[[RFC7253,RFC 7253]]], _The OCB Authenticated-Encryption Algorithm_.
 
-[[RNP]]
 [%bibitem]
 === RNP: A C library approach to OpenPGP
 id:: RNP


### PR DESCRIPTION
This reverts PR https://github.com/metanorma/mn-templates-ietf/pull/29 as that change is not necessary anymore, in the light of new updates in https://github.com/metanorma/metanorma-ietf/issues/187.

